### PR TITLE
Allow storing points/coordinates as struct arrays in addition to interleaved layout

### DIFF
--- a/format.md
+++ b/format.md
@@ -71,9 +71,9 @@ the child. The first and second child arrays must represent the x and y
 dimension; where z and m dimensions are both included, the z dimension must
 preceed the m dimension.
 
-**Coordinate (FixedSizeList)**: `FixedSizeList<double>[n_dim]`
+**Coordinate (interleaved)**: `FixedSizeList<double>[n_dim]`
 
-An array of point geometries may also be represented by a single array
+An array of coordinates may also be represented by a single array
 of interleaved coordinates. `n_dim` can be 2, 3, or 4 depending on the
 dimensionality of the geometries, and the field name of the list should
 be "xy", "xyz" or "xyzm", reflecting the dimensionality. Compared to
@@ -181,7 +181,7 @@ interpretation is unambiguous (e.g., for xy and xyzm coordinate interpretations)
 
 **Point (Struct)**
 
-Arrow type: `Struct<x: double, y: double, [z: double, [m: double>]]`
+Arrow type: `Struct<x: double, y: double>`
 
 For an array of Point geometries, one array per dimension is defined.
 

--- a/format.md
+++ b/format.md
@@ -164,7 +164,8 @@ types, and it is planned to add a description of this later.
 
 All geometry types should have fields and child names as suggested for each,
 however implementations must be able to ingest arrays with other names when the
-interpretation is unambiguous (e.g., for xy and xyzm coordinate interpretations).
+interpretation is unambiguous (e.g., for xy and xyzm interleaved coordinate
+interpretations).
 
 ## Concrete examples of the memory layout
 

--- a/format.md
+++ b/format.md
@@ -124,17 +124,6 @@ is a list of xy vertices. The child name of the outer list should be "polygons";
 the child name of the middle list should be "rings"; the child name of the
 inner list should be "vertices".
 
-**Well-known-binary (WKB)**: `Binary` or `LargeBinary` or `FixedSizeBinary`
-
-It may be useful for implementations that already have facilities to read
-and/or write well-known binary (WKB) to store features in this form without
-modification. When well-known binary is stored in an Arrow array, it should
-follow the convensions defined in the
-[GeoParquet specification](https://github.com/opengeospatial/geoparquet).
-Notably, it should use the ISO form instead of EWKB when Z or M dimensions
-are included and axis order is defined as easting, northing/longitude, latitude
-regardless of the order specified by the coordinate system.
-
 ### Missing values (nulls)
 
 Arrow supports missing values through a validity bitmap, and for nested data
@@ -297,7 +286,7 @@ WKT:
 
 ```
 [
-    "MULTIPOLYGON (((40 40, 20 45, 45 30, 40 40)), ((20 35, 10 30, 10 10, 30 5, 45 20, 20 35), (30 20, 20 15, 20 25, 30 20))",
+    "MULTIPOLYGON (((40 40, 20 45, 45 30, 40 40)), ((20 35, 10 30, 10 10, 30 5, 45 20, 20 35), (30 20, 20 15, 20 25, 30 20)))",
     "POLYGON ((35 10, 45 45, 15 40, 10 20, 35 10), (20 30, 35 35, 30 20, 20 30))",
     "MULTIPOLYGON (((30 20, 45 40, 10 40, 30 20)), ((15 5, 40 10, 10 20, 5 10, 15 5)))"
 ]

--- a/format.md
+++ b/format.md
@@ -49,45 +49,50 @@ The terminology for array types in this section is based on the
 GeoArrow proposes a packed columnar data format for the fundamental geometry
 types, using packed coordinate and offset arrays to define geometry objects.
 
-The inner level is always an array of points. For any geometry type except
+The inner level is always an array of coordinates. For any geometry type except
 Point, this inner level is nested in one or multiple
 [variable sized list](https://arrow.apache.org/docs/format/Columnar.html#variable-size-list-layout)
 arrays. In practice, this means we have additional arrays storing the offsets
 that denote where a new geometry, a new geometry part, or a new polygon ring
 starts.
 
-This specification supports points encoded as a Struct array storing the
+This specification supports coordinates encoded as a Struct array storing the
 coordinate values as separate arrays (i.e., `x: [x, x, ...], y: [y, y, y, ...]`)
 and a FixedSizeList of interleaved values (i.e., `[x, y, x, y, ...]`). As
-implementations evolve, this specification may grow to support other point
+implementations evolve, this specification may grow to support other coordinate
 representations or shrink to support only one if supporting multiple
 representations becomes a barrier to adoption.
 
-**Point (Struct)**: `Struct<x: double, y: double, [z: double, [m: double>]]`
+**Coordinate (Struct)**: `Struct<x: double, y: double, [z: double, [m: double>]]`
 
-An array of Point geometries is stored as a Struct array containing two or more
+An array of coordinates can be stored as a Struct array containing two or more
 child double arrays with names corresponding to the dimension represented by
 the child. The first and second child arrays must represent the x and y
 dimension; where z and m dimensions are both included, the z dimension must
 preceed the m dimension.
 
-**Point (FixedSizeList)**: `FixedSizeList<double>[n_dim]`
+**Coordinate (FixedSizeList)**: `FixedSizeList<double>[n_dim]`
 
 An array of point geometries may also be represented by a single array
 of interleaved coordinates. `n_dim` can be 2, 3, or 4 depending on the
 dimensionality of the geometries, and the field name of the list should
 be "xy", "xyz" or "xyzm", reflecting the dimensionality. Compared to
-the `Struct` representation of a point array, this representation may
+the `Struct` representation of a coordinate array, this representation may
 provide better performance for some operations and/or provide better
 compatability with the memory layout of existing libraries.
 
-**LineString**: `List<Point>`
+**Point**: `Coordinate`
+
+An array of point geometries is represented as an array of coordinates,
+which may be encoded according to either of the options above.
+
+**LineString**: `List<Coordinate>`
 
 An array of LineStrings is represented as a nested list array with one
 level of outer nesting: each element of the array (LineString) is a
 list of xy vertices. The child name of the outer list should be "vertices".
 
-**Polygon**: `List<List<Point>>`
+**Polygon**: `List<List<Coordinate>>`
 
 An array of Polygons is represented as a nested list array with two levels of
 outer nesting: each element of the array (Polygon) is a list of rings (the
@@ -95,13 +100,13 @@ first ring is the exterior ring, optional subsequent rings are interior
 rings), and each ring is a list of xy vertices. The child name of the outer
 list should be "rings"; the child name of the inner list should be "vertices".
 
-**MultiPoint**: `List<Point>`
+**MultiPoint**: `List<Coordinate>`
 
 An array of MultiPoints is represented as a nested list array, where each outer
 list is a single MultiPoint (i.e. a list of xy coordinates). The child name of
 the outer `List` should be "points".
 
-**MultiLineString**: `List<List<Point>>`
+**MultiLineString**: `List<List<Coordinate>>`
 
 An array of MultiLineStrings is represented as a nested list array with two
 levels of outer nesting: each element of the array (MultiLineString) is a
@@ -109,7 +114,7 @@ list of LineStrings, which consist itself of a list xy vertices (see above).
 The child name of the outer list should be "linestrings"; the child name of
 the inner list should be "vertices".
 
-**MultiPolygon**: `List<List<List<Point>>>`
+**MultiPolygon**: `List<List<List<Coordinate>>>`
 
 An array of MultiPolygons is represented as a nested list array with three
 levels of outer nesting: each element of the array (MultiPolygon) is a list

--- a/format.md
+++ b/format.md
@@ -63,7 +63,7 @@ implementations evolve, this specification may grow to support other coordinate
 representations or shrink to support only one if supporting multiple
 representations becomes a barrier to adoption.
 
-**Coordinate (Struct)**: `Struct<x: double, y: double, [z: double, [m: double>]]`
+**Coordinate (separated)**: `Struct<x: double, y: double, [z: double, [m: double>]]`
 
 An array of coordinates can be stored as a Struct array containing two or more
 child double arrays with names corresponding to the dimension represented by


### PR DESCRIPTION
The comment by @apps4uco in #16 is the latest in a number expressing surprise at the way that the current geoarrow spec suggest that points be stored. While I think that our current spec (xyzxyzxyzxyz) has value somewhere, it's unintuitive to enough everybody I've talked to that I think we should consider changing our initial spec version to (xxxxxx, yyyyyy). Since we started blogging and tweeting about this - largely for the purposes of generating this kind of discussion - all we have had are comments about why we didn't choose (xxxxxx, yyyyyy). I became involved after this initial decision had been made and I think it's the perfect time to change it (i.e., before any implementations actually exist).

The best arguments to store points as `Struct <x: [...], y: [...]>` by default are:

- Arrow is a columnar format and storing points rowwise is ideologically opposed to the specification. Practically, Arrow has a lot of tooling around working with data in this form (for example, we don't need any special code to access the `x` or `y` values from the inner points array meaning we might be able to implement more operations without custom C or C++ kernels).
- The child name for the `FixedSizeList` array might be deprecated in Arrow, meaning we probably shouldn't rely on it to store dimension information (https://issues.apache.org/jira/browse/ARROW-14999).
- Point geometries are often stored in Arrow format (or any table) as one column for x and one column for y. This is also how point clouds typically store coordinates (to my reading of PDAL's list of reasons why it had to split off from other geometry representations).
- Kernels that don't care about the `z` or `m` values don't have to be rewritten to be used for `xyz`, `xym`, or `xyzm` geometries (the first child is always X and the second child is always Y regardless of dimension). A *lot* of geometry kernels fall into this category. I'm personally sick of the number of times I've had to parameterize `coord_size`, `z_index` and `m_index`...this really does make writing kernels harder.
- File implementations like Parquet store min/max values per chunk, I believe even for nested arrays. This means we can more easily use column statistics for predicate pushdown when reading Parquet files.

The only reason I know about to use the current spec (`[x y, x y, x y]`) is  that it more closely matches how WKB does it and that it uses fewer buffers. This isn't to say it doesn't have any other advantages, but I think there's enough anecdotal evidence to put the burden of proof the other way around: if storing coordinates as `[x y, x y, x y]` in an Arrow array has value, its value must (in my opinion) be proved.]