### PR TITLE
Add WKB/WKT to memory layout and extension types

### DIFF
--- a/extension-types.md
+++ b/extension-types.md
@@ -28,7 +28,7 @@ information.
 When GeoArrow-encoded Arrays have the `ARROW:extension:name` metadata
 field set, it should be set to one of `geoarrow.point`, `geoarrow.linestring`,
 `geoarrow.polygon`, `geoarrow.multipoint`, `geoarrow.multilinestring`,
-`geoarrow.multipolygon`, or `geoarrow.wkb`. These names correspond
+`geoarrow.multipolygon`, `geoarrow.wkb`, or `geoarrow.wkb`. These names correspond
 to the memory layouts and value constraints described in
 [GeoArrow memory layout specification](format.md). The `ARROW:extension:name`
 and `ARROW:extension:metadata` metadata fields must only be set for the Array

--- a/extension-types.md
+++ b/extension-types.md
@@ -28,7 +28,7 @@ information.
 When GeoArrow-encoded Arrays have the `ARROW:extension:name` metadata
 field set, it should be set to one of `geoarrow.point`, `geoarrow.linestring`,
 `geoarrow.polygon`, `geoarrow.multipoint`, `geoarrow.multilinestring`,
-`geoarrow.multipolygon`, `geoarrow.wkb`, or `geoarrow.wkb`. These names correspond
+`geoarrow.multipolygon`, `geoarrow.wkb`, or `geoarrow.wkt`. These names correspond
 to the memory layouts and value constraints described in
 [GeoArrow memory layout specification](format.md). The `ARROW:extension:name`
 and `ARROW:extension:metadata` metadata fields must only be set for the Array

--- a/format.md
+++ b/format.md
@@ -140,7 +140,7 @@ inner list should be "vertices".
 It may be useful for implementations that already have facilities to read
 and/or write well-known binary (WKB) to store features in this form without
 modification. When well-known binary is stored in an Arrow array, it should
-follow the convensions defined in the
+follow the conventions defined in the
 [GeoParquet specification](https://github.com/opengeospatial/geoparquet).
 Notably, it should use the ISO form instead of EWKB when Z or M dimensions
 are included and axis order is defined as easting, northing/longitude, latitude

--- a/format.md
+++ b/format.md
@@ -191,7 +191,7 @@ WKB where possible; however, consumers may accept EWKB or ISO flavoured WKB.
 Consumers may ignore any embedded SRID values in EWKB.
 
 The Arrow `Binary` type is composed of two buffers: a buffer
-of `int32` offsets and a `char` data buffer. The `LargeBinary` type is
+of `int32` offsets and a `uint8` data buffer. The `LargeBinary` type is
 composed of an `int64` offset buffer and a `uint8` data buffer.
 
 **Well-known text (WKT)**: `Utf8` or `LargeUtf8`

--- a/format.md
+++ b/format.md
@@ -187,7 +187,8 @@ propagate critical metadata (e.g., CRS).
 It may be useful for implementations that already have facilities to read
 and/or write well-known binary (WKB) to store features in this form without
 modification. For maximum compatibility producers should write ISO-flavoured
-WKB where possible; however, either EWKB or ISO flavoured WKB is permitted.
+WKB where possible; however, consumers may accept EWKB or ISO flavoured WKB.
+Consumers may ignore any embedded SRID values in EWKB.
 
 The Arrow `Binary` type is composed of two buffers: a buffer
 of `int32` offsets and a `char` data buffer. The `LargeBinary` type is

--- a/format.md
+++ b/format.md
@@ -124,37 +124,6 @@ is a list of xy vertices. The child name of the outer list should be "polygons";
 the child name of the middle list should be "rings"; the child name of the
 inner list should be "vertices".
 
-## Serialized encodings
-
-### Motivation
-
-Whereas there are many advantages to storing data in the native encoding,
-many producers of geospatial data (e.g., database drivers, file readers)
-do not have a full geospatial stack at their disposal. The serialized encodings
-are provided to accomodate these producers and provide every opportunity to
-propagate critical metadata (e.g., CRS).
-
-**Well-known binary (WKB)**: `Binary` or `LargeBinary`
-
-It may be useful for implementations that already have facilities to read
-and/or write well-known binary (WKB) to store features in this form without
-modification. For maximum compatibility producers should write ISO-flavoured
-WKB where possible; however, either EWKB or ISO flavoured WKB is permitted.
-
-The Arrow `Binary` type is composed of two buffers: a buffer
-of `int32` offsets and a `char` data buffer. The `LargeBinary` type is
-composed of an `int64` offset buffer and a `uint8` data buffer.
-
-**Well-known text (WKT)**: `Utf8` or `LargeUtf8`
-
-It may be useful for implementations that already have facilities to read
-and/or write well-known binary (WKT) to store features in this form without
-modification.
-
-The Arrow `Utf8` type is composed of two buffers: a buffer
-of `int32` offsets and a `char` data buffer. The `LargeUtf8` type is composed of
-an `int64` offset buffer and a `char` data buffer.
-
 ### Missing values (nulls)
 
 Arrow supports missing values through a validity bitmap, and for nested data
@@ -166,8 +135,6 @@ fields can be marked explicitly as non-nullable, but this is not required.
 In practice this means you can have a missing geometry, but not a geometry
 with a null part or null (co)ordinate (for example, a polygon with a null
 ring or a point with a null x value).
-
-## Additional considerations
 
 ### Empty geometries
 
@@ -204,6 +171,37 @@ All geometry types that contain field names should have field and child names
 as suggested for each; however, implementations must be able to ingest arrays
 with other names when the interpretation is unambiguous (e.g., for xy and
 xyzm interleaved coordinate interpretations).
+
+## Serialized encodings
+
+### Motivation
+
+Whereas there are many advantages to storing data in the native encoding,
+many producers of geospatial data (e.g., database drivers, file readers)
+do not have a full geospatial stack at their disposal. The serialized encodings
+are provided to accomodate these producers and provide every opportunity to
+propagate critical metadata (e.g., CRS).
+
+**Well-known binary (WKB)**: `Binary` or `LargeBinary`
+
+It may be useful for implementations that already have facilities to read
+and/or write well-known binary (WKB) to store features in this form without
+modification. For maximum compatibility producers should write ISO-flavoured
+WKB where possible; however, either EWKB or ISO flavoured WKB is permitted.
+
+The Arrow `Binary` type is composed of two buffers: a buffer
+of `int32` offsets and a `char` data buffer. The `LargeBinary` type is
+composed of an `int64` offset buffer and a `uint8` data buffer.
+
+**Well-known text (WKT)**: `Utf8` or `LargeUtf8`
+
+It may be useful for implementations that already have facilities to read
+and/or write well-known binary (WKT) to store features in this form without
+modification.
+
+The Arrow `Utf8` type is composed of two buffers: a buffer
+of `int32` offsets and a `char` data buffer. The `LargeUtf8` type is composed of
+an `int64` offset buffer and a `char` data buffer.
 
 ## Concrete examples of the memory layout
 

--- a/format.md
+++ b/format.md
@@ -46,6 +46,8 @@ interpret as actual geometries.
 [FlatGeoBuf](https://flatgeobuf.org/) is similar on various aspects, but is
 record-oriented, while Arrow is column-oriented.
 
+### Memory layouts
+
 GeoArrow proposes a packed columnar data format for the fundamental geometry
 types, using packed coordinate and offset arrays to define geometry objects.
 
@@ -138,43 +140,41 @@ ring or a point with a null x value).
 
 ### Empty geometries
 
-Except for Points, empty geometries in a native encoding can be faithfully
-represented as an empty inner list.
+Except for Points, empty geometries can be faithfully represented as an
+empty inner list.
 
 Empty points can be represented as `POINT (NaN NaN)`.
 
 ### GeometryCollection
 
-GeometryCollection features containing mixed geometry types cannot yet be
-represented using a native encoding. GeometryCollection features can be
-represented using a serialized encoding (e.g., WKB) and future support
-is planned using an
-[Arrow union type](https://arrow.apache.org/docs/format/Columnar.html#union-layout)
-of native encodings.
+GeometryCollection features cannot yet be represented using a native encoding. Future
+support is planned using an
+[Arrow union type](https://arrow.apache.org/docs/format/Columnar.html#union-layout).
+
+GeometryCollection features can be represented using a serialized encoding (WKB or WKT),
+see below.
 
 ### Mixed Geometry types
 
-Arrays containing features with mixed geometry types cannot yet be
-represented using a native encoding. Arrays with mixed geometry types
-can be represented using a serialized encoding (e.g., WKB) and future
-support is planned using an
-[Arrow union type](https://arrow.apache.org/docs/format/Columnar.html#union-layout)
-of native encodings.
+Arrays containing features of mixed geometry types cannot yet be represented using a
+native encoding. Future support is planned using an
+[Arrow union type](https://arrow.apache.org/docs/format/Columnar.html#union-layout).
 
-Note that single and multi geometries of the same type (for example,
-Polygon and MultiPolygon) can be stored together in a Multi encoding
-(e.g., MultiPolygon).
+Note that single and multi geometries of the same type can be stored together in a Multi
+encoding. For example, a mix of Polygon and MultiPolygon can be stored as MultiPolygons,
+with a Polygon being represented as a length-1 MultiPolygon.
+
+Arrays with mixed geometry types can be represented using a serialized encoding (WKB or
+WKT), see below.
 
 ### Field and child names
 
-All geometry types that contain field names should have field and child names
-as suggested for each; however, implementations must be able to ingest arrays
-with other names when the interpretation is unambiguous (e.g., for xy and
-xyzm interleaved coordinate interpretations).
+All geometry types should have field and child names as suggested for each;
+however, implementations must be able to ingest arrays with other names when the
+interpretation is unambiguous (e.g., for xy and xyzm interleaved coordinate
+interpretations).
 
 ## Serialized encodings
-
-### Motivation
 
 Whereas there are many advantages to storing data in the native encoding,
 many producers of geospatial data (e.g., database drivers, file readers)
@@ -197,7 +197,7 @@ composed of an `int64` offset buffer and a `uint8` data buffer.
 **Well-known text (WKT)**: `Utf8` or `LargeUtf8`
 
 It may be useful for implementations that already have facilities to read
-and/or write well-known binary (WKT) to store features in this form without
+and/or write well-known text (WKT) to store features in this form without
 modification.
 
 The Arrow `Utf8` type is composed of two buffers: a buffer

--- a/format.md
+++ b/format.md
@@ -124,6 +124,27 @@ is a list of xy vertices. The child name of the outer list should be "polygons";
 the child name of the middle list should be "rings"; the child name of the
 inner list should be "vertices".
 
+**Well-known binary (WKB)**: `Binary` or `LargeBinary` or `FixedSizeBinary`
+
+It may be useful for implementations that already have facilities to read
+and/or write well-known binary (WKB) to store features in this form without
+modification. When well-known binary is stored in an Arrow array, it should
+follow the convensions defined in the
+[GeoParquet specification](https://github.com/opengeospatial/geoparquet).
+Notably, it should use the ISO form instead of EWKB when Z or M dimensions
+are included and axis order is defined as easting, northing/longitude, latitude
+regardless of the order specified by the coordinate system. Producers may store
+EWKB or invalid WKB in a GeoArrow WKB array and consumers may error if they
+encounter unsupported or invalid WKB.
+
+**Well-known text (WKT)**: `Utf8` or `LargeUtf8`
+
+It may be useful for implementations that already have facilities to read
+and/or write well-known binary (WKT) to store features in this form without
+modification. It should follow as closely as possible the specifications
+for WKB arrays (e.g., axis order is defined as easting, northing/longitude,
+latitude).
+
 ### Missing values (nulls)
 
 Arrow supports missing values through a validity bitmap, and for nested data

--- a/format.md
+++ b/format.md
@@ -43,8 +43,17 @@ record-oriented, while Arrow is column-oriented.
 
 ## Format
 
+The GeoArrow specification provides both a packed native columnar format encoding
+and a set of serialized encodings. As explained above, there are many advantages
+to storing data in the columnar encoing; however, many potential producers of
+geospatial data (e.g., database drivers, file readers) do not have a full
+geospatial stack at their disposal. The serialized encodings are provided to
+accomodate these producers and ensure critical metadata (e.g., CRS) is not lost.
+
 The terminology for array types in this section is based on the
 [Arrow Columnar Format specification](https://arrow.apache.org/docs/format/Columnar.html).
+
+### Native encodings
 
 GeoArrow proposes a packed columnar data format for the fundamental geometry
 types, using packed coordinate and offset arrays to define geometry objects.
@@ -123,6 +132,8 @@ exterior ring, optional subsequent rings are interior rings), and each ring
 is a list of xy vertices. The child name of the outer list should be "polygons";
 the child name of the middle list should be "rings"; the child name of the
 inner list should be "vertices".
+
+### Serialized encodings
 
 **Well-known binary (WKB)**: `Binary` or `LargeBinary` or `FixedSizeBinary`
 

--- a/format.md
+++ b/format.md
@@ -143,7 +143,7 @@ modification. When well-known binary is stored in an Arrow array, it should
 follow the conventions defined in the
 [GeoParquet specification](https://github.com/opengeospatial/geoparquet).
 Notably, it should use the ISO form instead of EWKB when Z or M dimensions
-are included and axis order is defined as easting, northing/longitude, latitude
+are included and axis order is defined as easting, northing or longitude, latitude
 regardless of the order specified by the coordinate system. Producers may store
 EWKB or invalid WKB in a GeoArrow WKB array and consumers may error if they
 encounter unsupported or invalid WKB.


### PR DESCRIPTION
As briefly discussed in #14, there are some motivating use-cases to providing an explicit path to attaching GeoArrow metadata to WKT and WKB arrays. Notably, this makes it cheap (or free) for a producer to produce GeoArrow and attach a CRS. For example:

- In PostGIS, a COPY query will serialize geometry columns to EWKB for transport over the wire. Currently the ADBC driver passes these on verbatim as binary but could attach `geoarrow.wkb` (or `geoarrow.ewkb`?): https://github.com/apache/arrow-adbc/issues/546#issuecomment-1533544042
- In Snowflake, geometry/geography columns come across the wire as GeoJSON (I think).
- In BigQuery, geography columns arrive as WKT (with spherical edges)

I think the main benefit for allowing these as extension types is that it reduces the chance that the CRS will be lost when the array crosses a boundary (IPC or C Data).

This PR adds a memory layout and extension name for WKT and WKB-encoded arrays. I could add GeoJSON too but I'm less familiar with the details and I didn't implement a reader or writer yet (so it would be an extension name with no implementation yet).