### PR TITLE
Clarify representation of EMPTY in format.md

### DIFF
--- a/format.md
+++ b/format.md
@@ -141,7 +141,7 @@ ring or a point with a null x value).
 ### Empty geometries
 
 Except for Points, empty geometries can be faithfully represented as an
-empty inner list.
+empty outer list.
 
 Empty points can be represented as `POINT (NaN NaN)`.
 


### PR DESCRIPTION
Closes #29. I believe "outer" is what was intended here (i.e., we represent empties the same way that WKB represents empties).