### PR TITLE
Clarify CRS language around not escaping JSON as a string

### DIFF
--- a/extension-types.md
+++ b/extension-types.md
@@ -55,7 +55,11 @@ The following keys in the JSON metadata object are supported:
     - Omitted, indicating that the producer does not have any information about
       the CRS.
 
-  For maximum compatibility, producers should write PROJJSON where possible.
+  For maximum compatibility, producers should write PROJJSON. Producers should not
+  write an escaped JSON object to the `crs` key (i.e., when serializing an unknown
+  string to the `crs` key, producers should check for a valid JSON object and should
+  not escape the input and write it as a string).
+
   Note that regardless of the axis order specified by the CRS, axis order will be interpreted
   according to the wording in the
   [GeoPackage WKB binary encoding](https://www.geopackage.org/spec130/index.html#gpb_format):

--- a/extension-types.md
+++ b/extension-types.md
@@ -57,6 +57,7 @@ The following keys in the JSON metadata object are supported:
 
   For maximum compatibility, producers should write PROJJSON where possible.
   Note that regardless of the axis order specified by the CRS, axis order will be interpreted
+  according to the wording in the
   [GeoPackage WKB binary encoding](https://www.geopackage.org/spec130/index.html#gpb_format):
   axis order is always (longitude, latitude) and (easting, northing)
   regardless of the the axis order encoded in the CRS specification.


### PR DESCRIPTION
I'm happy to adapt this language...I tried to make it actionable: a CRS-unaware implementation can usually check if something is a valid object (even geoarrow-c can do this), so that's the language I used (as opposed to "valid PROJJSON", since anything with the ability to actually determine that wouldn't be writing a string anyway).

A follow-up to https://github.com/geoarrow/geoarrow/pull/40#discussion_r1862635728