### PR TITLE
Add language around edges to be more explicit and cover practical implementation considerations

### DIFF
--- a/extension-types.md
+++ b/extension-types.md
@@ -97,7 +97,7 @@ The following keys in the JSON metadata object are supported:
   specifically into one of these representations).
 
 - `edges`: An optional JSON string describing the interpretation of edges
-  between explicitly defined vertices. This does typically affect format
+  between explicitly defined vertices. This does not affect format
   conversions (e.g., parsing `geoarrow.wkb` as `geoarrow.linestring`),
   but does affect distance, intersection, overlay, length, and area calculations.
   The `edges` key must be omitted or be one of:

--- a/extension-types.md
+++ b/extension-types.md
@@ -113,18 +113,20 @@ The following keys in the JSON metadata object are supported:
     for calculating distances along this trajectory is the
     [Haversine Formula](https://en.wikipedia.org/wiki/Haversine_formula).
   - `"vincenty"`: Edges in the longitude-latitude dimensions follow a path calculated
-    using [Vincenty's formula](https://en.wikipedia.org/wiki/Vincenty%27s_formulae).
+    using [Vincenty's formula](https://en.wikipedia.org/wiki/Vincenty%27s_formulae) and
+    the ellipsoid specified by the `"crs"`.
   - `"thomas"`:  Edges in the longitude-latitude dimensions follow a path calculated by
     the fomula in Thomas, Paul D. Spheroidal geodesics, reference systems, & local geometry.
-    US Naval Oceanographic Office, 1970.
+    US Naval Oceanographic Office, 1970 using the ellipsoid specified by the `"crs"`.
   - `"andoyer"`: Edges in the longitude-latitude dimensions follow a path calculated by
     the fomula in Thomas, Paul D. Mathematical models for navigation systems. US Naval
-    Oceanographic Office, 1965.
+    Oceanographic Office, 1965 using the ellipsoid specified by the `"crs"`.
   - `"karney"`: Edges in the longitude-latitude dimensions follow a path calculated by
     the fomula in
     [Karney, Charles FF. "Algorithms for geodesics." Journal of Geodesy 87 (2013): 43-55](https://link.springer.com/content/pdf/10.1007/s00190-012-0578-z.pdf)
-    and [GeographicLib](https://geographiclib.sourceforge.io/) (which is also available
-    via modern versions of PROJ).
+    and [GeographicLib](https://geographiclib.sourceforge.io/)
+    using the ellipsoid specified by the `"crs"`. GeographicLib available via modern
+    versions of PROJ.
 
   If the `edges` key is omitted, edges will be interpreted following the language of
   [Simple features access](https://www.opengeospatial.org/standards/sfa):

--- a/extension-types.md
+++ b/extension-types.md
@@ -107,8 +107,7 @@ The following keys in the JSON metadata object are supported:
     interpretation is used by
     [BigQuery Geography](https://cloud.google.com/bigquery/docs/geospatial-data#coordinate_systems_and_edges),
     and [Snowflake Geography](https://docs.snowflake.com/en/sql-reference/data-types-geospatial).
-    A common library for
-    interpreting edges in this way is
+    A common library for interpreting edges in this way is
     [Google's s2geometry](https://github.com/google/s2geometry).
   - `"geodesic"`: Edges follow the shortest distance between vertices on the
     ellipsoid defined by the `crs` key. This edge interpretation is used by
@@ -145,7 +144,8 @@ The following keys in the JSON metadata object are supported:
 
   Implementations may implicitly import arrays with an unsupported edge type if the
   arrays do not contain edges. Implementations may otherwise import arrays with an
-  unsupported edge type with an explicit opt-in from a user or a prominent warning.
+  unsupported edge type with an explicit opt-in from a user or if accompanied
+  by a prominent warning.
 
 If all metadata keys are omitted, the `ARROW:extension:metadata` should
 also be omitted.


### PR DESCRIPTION
This PR is an attempt to improve the language around the "edges" key, which was a little vague. We've done more research since then and have some specific examples and use cases where implementations and specifications have struggled. Notably, this PR:

- Adds a "geodesic" option. I only knew about the spherical approximation because I'd only worked with s2, but it's been rightly pointed out that geodesic edges that consider the ellipsoid are a thing in several major engines.
- Adds examples of producers and consumers that use each edge type
- Adds explicit language around "planar" from simple features access
- Adds practical considerations around importing an array with an unsupported edge type (basically: you can import them silently if there are no edges; you should force an opt-in or display a prominent warning otherwise).

I'd love to get this in to 0.2. if we can get consensus around this language!