### PR TITLE
Fix wraparound dimensions for 'box' memory layout

### DIFF
--- a/format.md
+++ b/format.md
@@ -286,15 +286,14 @@ The child fields MUST be named and ordered as follows for the given dimension:
 These bounds refer to a set of points such that a value `v` intersects a box if
 `v >= vmin` AND `v <= vmax` for `v` in [`x`, `y`, `z`, `m`].
 
-If `xmin > xmax`, a box may intersect a value `x` if  `x >= xmin` OR `x <= xmax` and if 
-`ymin > ymax`, a box may intersect a value `y` if  `y >= ymin` OR `y <= ymax`. This behaviour
+If `xmin > xmax`, a box may intersect a value `x` if  `x >= xmin` OR `x <= xmax`. This behaviour
 is designed to support compact bounds for geometries that happen to straddle the antimeridian.
 This behaviour ensures that a
 [GeoJSON bounding box](https://datatracker.ietf.org/doc/html/rfc7946#section-5.2), a
 GeoParquet file metadata bounding box (also based on GeoJSON), and a box derived from the
 Iceberg 3.0 specification for geometry and geography column statistics may be expressed
 as a GeoArrow Box without inspecting values. This exception does not apply to dimensions
-other than `x` and `y`.
+other than `x`.
 
 Empty ranges may be expressed by setting the `min` value to infinity and the `max` value to
 -infinity for any dimension.


### PR DESCRIPTION
The Parquet and Iceberg specifications changed at the last minute to (thankfully) only allow wraparound in the X direction. I had missed that update until I was reminded by a reviewer of the Parquet GEOMETRY PR!

Parquet spec reference: https://github.com/apache/parquet-format/blob/master/Geospatial.md#bounding-box