### PR TITLE
Clarify text around internal coordinate dimension

### DIFF
--- a/format.md
+++ b/format.md
@@ -112,7 +112,8 @@ List<Coordinate>
 
 An array of LineStrings is represented as a nested list array with one
 level of outer nesting: each element of the array (LineString) is a
-list of xy vertices. The child name of the outer list should be "vertices".
+list of coordinate vertices. The child name of the outer list should be
+"vertices".
 
 #### Polygon
 
@@ -123,10 +124,10 @@ List<List<Coordinate>>
 An array of Polygons is represented as a nested list array with two levels of
 outer nesting: each element of the array (Polygon) is a list of rings (the
 first ring is the exterior ring, optional subsequent rings are interior
-rings), and each ring is a list of xy vertices. The child name of the outer
-list should be "rings"; the child name of the inner list should be "vertices".
-The first coordinate and the last coordinate of a ring must be identical
-(i.e., rings must be closed).
+rings), and each ring is a list of coordinate vertices. The child name of the
+outer list should be "rings"; the child name of the inner list should be
+"vertices". The first coordinate and the last coordinate of a ring must be
+identical (i.e., rings must be closed).
 
 #### MultiPoint
 
@@ -135,7 +136,7 @@ List<Coordinate>
 ```
 
 An array of MultiPoints is represented as a nested list array, where each outer
-list is a single MultiPoint (i.e. a list of xy coordinates). The child name of
+list is a single MultiPoint (i.e. a list of coordinates). The child name of
 the outer `List` should be "points".
 
 #### MultiLineString
@@ -146,9 +147,9 @@ List<List<Coordinate>>
 
 An array of MultiLineStrings is represented as a nested list array with two
 levels of outer nesting: each element of the array (MultiLineString) is a
-list of LineStrings, which consist itself of a list xy vertices (see above).
-The child name of the outer list should be "linestrings"; the child name of
-the inner list should be "vertices".
+list of LineStrings, which consist itself of a list coordinate vertices (see
+above). The child name of the outer list should be "linestrings"; the child name
+of the inner list should be "vertices".
 
 #### MultiPolygon
 
@@ -160,9 +161,9 @@ An array of MultiPolygons is represented as a nested list array with three
 levels of outer nesting: each element of the array (MultiPolygon) is a list
 of Polygons, which consist itself of a list of rings (the first ring is the
 exterior ring, optional subsequent rings are interior rings), and each ring
-is a list of xy vertices. The child name of the outer list should be "polygons";
-the child name of the middle list should be "rings"; the child name of the
-inner list should be "vertices".
+is a list of coordinate vertices. The child name of the outer list should be
+"polygons"; the child name of the middle list should be "rings"; the child name
+of the inner list should be "vertices".
 
 #### GeometryCollection
 


### PR DESCRIPTION
A few places of the format spec refer to `xy vertices`, and I think it may be clearer to remove/replace the term `xy` so that readers don't assume they only support two-dimensional data.